### PR TITLE
Tutorial disambiguation

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -29,7 +29,7 @@ Every interaction is univocally defined by its endpoints, ``u`` and ``v``, as we
 
 	g.add_interaction(u=1, v=2, t=0)
 
-Moreover, also interaction duration can be specified at creation time:
+Moreover, also interaction duration can be specified at creation time, by setting kwarg ``e`` equal to the last timestamp at which the interaction is present:
 
 .. code:: python
 


### PR DESCRIPTION
Hi Giulio,

Thank you for this amazing package!

I created this issue to disambiguate the usage of kwarg e of the dn.DynGraph.add_interaction method. I found your description slightly misleading, as add_interaction expects not the duration, but the endpoint of the respective time period. I've spent quite some time figuring out what's wrong with my network.

I hope I can help others avoid this problem, even if it's just a minor issue.