### PR TITLE
decorators.py: Replace deprecated NetworkX `is_string_like` function

### DIFF
--- a/dynetx/utils/decorators.py
+++ b/dynetx/utils/decorators.py
@@ -3,7 +3,6 @@ from os.path import splitext
 
 import networkx as nx
 from decorator import decorator
-from networkx.utils import is_string_like
 
 __all__ = [
     'open_file',
@@ -167,7 +166,7 @@ def open_file(path_arg, mode='r'):
         # Now we have the path_arg. There are two types of input to consider:
         #   1) string representing a path that should be opened
         #   2) an already opened file object
-        if is_string_like(path):
+        if isinstance(path, str):
             ext = splitext(path)[1]
             fobj = _dispatch_dict[ext](path, mode=mode)
             close_fobj = True


### PR DESCRIPTION
The `is_string_like()` method from `networkx.utils` was removed in NetworkX 3.0 (see https://github.com/networkx/networkx/pull/5738). This commit changes this to the Python built-in function [isinstance()](https://docs.python.org/3/library/functions.html#isinstance).