### PR TITLE
CI: Test on Python 3.10 and 3.11, run once a month

### DIFF
--- a/.github/workflows/test_ubuntu.yml
+++ b/.github/workflows/test_ubuntu.yml
@@ -8,6 +8,9 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
+  workflow_dispatch:
+  schedule:
+    - cron: "0 6 1 * *"  # The 1st day of each month at 06:00 UTC
 
 jobs:
   build:
@@ -16,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Some tweaks in the CI configuration:
- Add test jobs for Python 3.10 and 3.11, remove Python 3.7.
- Run once a month. This helps to detect and trace back when and why CI failed if dependencies are updated or the build environment changes.