### PR TITLE
Add wiki-link in tutorial.

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -2,7 +2,7 @@
 DyNetx Tutorial
 ***************
 
-DyNetx is built upon networkx and is designed to configure, model and analyze dynamic networks.
+DyNetx is built upon networkx and is designed to configure, model and `analyze dynamic networks <https://en.wikipedia.org/wiki/Dynamic_network_analysis>`_.
 
 In this tutorial we will introduce the ``DynGraph`` object that can be used to describe undirected, temporal graphs.
 


### PR DESCRIPTION
I've been doing some searching for existing datastructure to maintain dynamic connectivity in general graphs, and I stumbled on this. I then learned that the dynamic graphs implemented by this library have to do with maintaining a history of how a graph is evolving over time, and it doesn't seem to have the tools I'm looking for. The tutorial and docs are a bit terse, so it took me a while to realize this. I think adding a link to the wiki page on dynamic network analysis - which more clearly defines the context - would have been helpful to me, so I'm writing this.

----

PS: if you have any recommendations for Python packages that do work with maintaining data structures to handle dynamic connectivity let me know. I know networkx itself has a [UnionFind](https://networkx.org/documentation/stable/_modules/networkx/utils/union_find.html#UnionFind.union) data structure (even though it's not integrated into a graph structure, I've written [wrapper code](https://github.com/Erotemic/graphid/blob/main/graphid/util/nx_dynamic_graph.py#L128) that maintains UnionFind with the graph). What I'm really looking for now, is something that works similarly for directed graphs (i.e. quickly query all ancestors and descendents and update that as the graph is modified). 