### PR TITLE
Adjust time_slice method to return sliced graph with correct interactions

### DIFF
--- a/dynetx/classes/dyngraph.py
+++ b/dynetx/classes/dyngraph.py
@@ -356,7 +356,10 @@ class DynGraph(nx.Graph):
             self._node[v] = {}
 
         if not isinstance(t, list):
-            t = [t, t]
+            if e is not None and e > t:
+                t = [t, e - 1]
+            else:
+                t = [t, t]
 
         for idt in [t[0]]:
             if self.has_edge(u, v) and not self.edge_removal:
@@ -369,8 +372,6 @@ class DynGraph(nx.Graph):
                         self.time_to_edge[idt][(u, v, "+")] = None
 
         if e is not None and self.edge_removal:
-
-            t[1] = e - 1
             if e not in self.time_to_edge:
                 self.time_to_edge[e] = {(u, v, "-"): None}
             else:
@@ -1055,13 +1056,13 @@ class DynGraph(nx.Graph):
                     continue
 
                 if f_from >= a and i_to <= b:
-                    H.add_interaction(u, v, f_from, i_to)
+                    H.add_interaction(u, v, f_from, i_to + 1)
                 elif a >= f_from and i_to <= b:
-                    H.add_interaction(u, v, a, i_to)
+                    H.add_interaction(u, v, a, i_to + 1)
                 elif f_from>=a and b<= i_to:
-                    H.add_interaction(u, v, f_from, b)
+                    H.add_interaction(u, v, f_from, b + 1)
                 elif f_from <= a and b <= i_to:
-                    H.add_interaction(u, v, a, b)
+                    H.add_interaction(u, v, a, b + 1)
 
         for n in H.nodes():
             H._node[n] = self._node[n]


### PR DESCRIPTION
## Problem description

When using `time_slice` to create a time slice of a graph, the returned time slice contains wrong timestamps for the end of an interaction (which are always one unit to small) and the time slice does not take all interactions into account for directed graphs and reverses the direction of edges (see #135).

The terminology here was a bit confusing to me: when using `time_slice(t_from=0, t_to=2)`, I expect the graph to include all snapshots from `t=0` to *and including* `t=2`.  When adding an interaction `add_interaction(t=0, e=2)`, I expect the interaction to last from `t=0` to `t=1` and *vanish* at `e=2`. (I hope I interpret the terminology used by the library correctly).

The changes in this branch therefore add an additional time unit when creating the time slice to take this into account.

The changes also respect the direction of edges for directed graphs when checking for `seen` nodes and when creating a list of interactions.

This should fix #135.

## Example

```
G = dn.DynDiGraph()
G.add_interaction(0,1, t=0, e=2)
G.add_interaction(1,2, t=0)
G.add_interaction(2,4, t=0)
G.add_interaction(0,4, t=1)
G.add_interaction(4,5, t=1)
G.add_interaction(5,6, t=1)
G.add_interaction(7,1, t=2)
G.add_interaction(1,2, t=2)
G.add_interaction(2,3, t=2)
H = G.time_slice(0)
I = G.time_slice(0, 2)
```

Previous behavior:
```
>>> G.interactions()
[(0, 1, {'t': [[0, 1]]}), (0, 4, {'t': [[1, 1]]}), (1, 2, {'t': [[0, 0], [2, 2]]}), (1, 7, {'t': [[2, 2]]}), (2, 4, {'t': [[0, 0]]}), (2, 3, {'t': [[2, 2]]}), (4, 5, {'t': [[1, 1]]}), (5, 6, {'t': [[1, 1]]})]
>>> H.interactions()
[(0, 1, {'t': [[0, -1]]})]
>>> I.interactions()
[(0, 1, {'t': [[0, 0]]}), (2, 4, {'t': [[0, -1]]})]
```

Behavior after changes:
```
>>> G.interactions()
[(0, 1, {'t': [[0, 1]]}), (0, 4, {'t': [[1, 1]]}), (1, 2, {'t': [[0, 0], [2, 2]]}), (1, 7, {'t': [[2, 2]]}), (2, 4, {'t': [[0, 0]]}), (2, 3, {'t': [[2, 2]]}), (4, 5, {'t': [[1, 1]]}), (5, 6, {'t': [[1, 1]]})]
>>> H.interactions()
[(0, 1, {'t': [[0, 0]]}), (1, 2, {'t': [[0, 0]]}), (2, 4, {'t': [[0, 0]]})]
>>> I.interactions()
[(0, 1, {'t': [[0, 1]]}), (0, 4, {'t': [[1, 1]]}), (1, 2, {'t': [[0, 0], [2, 2]]}), (1, 7, {'t': [[2, 2]]}), (4, 2, {'t': [[0, 0]]}), (4, 5, {'t': [[1, 1]]}), (2, 3, {'t': [[2, 2]]}), (5, 6, {'t': [[1, 1]]})]
```